### PR TITLE
fixed typo preventing knife environment autocompletion from working

### DIFF
--- a/shell/knife_completion.sh
+++ b/shell/knife_completion.sh
@@ -50,7 +50,7 @@ _chef_roles() {
     _output_on_success knife role list
 }
 
-_chef_environemnts() {
+_chef_environments() {
     _output_on_success knife environment list
 }
 


### PR DESCRIPTION
one little transposition of letters. i can't believe it was this simple. your knife bash completion is the best one I've seen. i'd still love to add some caching but at least for now this fixes a bug that's been bugging me for a while but never looked deeply enough.
