### PR TITLE
quote args, just in case

### DIFF
--- a/shell/knife_completion.sh
+++ b/shell/knife_completion.sh
@@ -26,8 +26,8 @@ _flatten_command() {
 
 _output_on_success() {
     local out
-    out=$($* 2>/dev/null)
-    [ $? -eq 0 ] && echo $out
+    out=$("$@" 2>/dev/null)
+    [ $? -eq 0 ] && echo "$out"
 }
 
 _chef_nodes() {


### PR DESCRIPTION
quote, to avoid shell dequoting, so spaces would matter (preserved in args, preserved in output)
