### PR TITLE
make exported jsons prettier.

### DIFF
--- a/plugins/backup_export.rb
+++ b/plugins/backup_export.rb
@@ -17,6 +17,7 @@
 #
 
 require 'chef/node'
+require 'json'
 
 module ServerBackup
   class BackupExport < Chef::Knife
@@ -62,7 +63,7 @@ module ServerBackup
           ui.msg "Backing up data bag #{bag_name} item #{item_name}"
           item = Chef::DataBagItem.load(bag_name, item_name)
           File.open(File.join(dir, bag_name, "#{item_name}.json"), "w") do |dbag_file|
-            dbag_file.print(item.raw_data.to_json)
+            dbag_file.print(JSON.pretty_generate(item.raw_data))
           end
         end
       end
@@ -77,7 +78,7 @@ module ServerBackup
         ui.msg "Backing up #{component} #{component_name}"
         component_obj = klass.load(component_name)
         File.open(File.join(dir, "#{component_name}.json"), "w") do |component_file|
-          component_file.print(component_obj.to_json)
+          component_file.print(JSON.pretty_generate(component_obj.to_hash))
         end
       end
     end


### PR DESCRIPTION
Exported jsons are written in one line and they are difficult to read.
This change will make the exported jsons multiline and easier to read.